### PR TITLE
Added missing NSString category method "validEmail"

### DIFF
--- a/NSString+Validate.h
+++ b/NSString+Validate.h
@@ -1,0 +1,15 @@
+//
+//  NSString+Validate.h
+//  Stock +
+//
+//  Created by Andrew on 4/23/15.
+//  Copyright (c) 2015 Chimp Studios. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NSString (Validate)
+
+- (BOOL)validEmail;
+
+@end

--- a/NSString+Validate.m
+++ b/NSString+Validate.m
@@ -1,0 +1,27 @@
+//
+//  NSString+Validate.m
+//  Stock +
+//
+//  Created by Andrew on 4/23/15.
+//  Copyright (c) 2015 Chimp Studios. All rights reserved.
+//
+
+#import "NSString+Validate.h"
+
+@implementation NSString (Validate)
+
+- (BOOL)validEmail {
+    NSString *emailRegex =
+    @"(?:[a-z0-9!#$%\\&'*+/=?\\^_`{|}~-]+(?:\\.[a-z0-9!#$%\\&'*+/=?\\^_`{|}"
+    @"~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\"
+    @"x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[a-z0-9](?:[a-"
+    @"z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\\[(?:(?:25[0-5"
+    @"]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-"
+    @"9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21"
+    @"-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])";
+    NSPredicate *emailTest = [NSPredicate predicateWithFormat:@"SELF MATCHES[c] %@", emailRegex];
+    
+    return [emailTest evaluateWithObject:self];
+}
+
+@end

--- a/NSTextField+Validation.m
+++ b/NSTextField+Validation.m
@@ -6,6 +6,7 @@
 //
 
 #import "NSTextField+Validation.h"
+#import "NSString+Validate.h"
 #import <objc/runtime.h>
 
 static NSColor *kValidationTextFieldBackgroundColour;


### PR DESCRIPTION
Current project missing method validEmail and will not compile.  This commit adds the method and allows the code to compile.
